### PR TITLE
Use Display trait

### DIFF
--- a/src/equation.rs
+++ b/src/equation.rs
@@ -81,12 +81,10 @@ impl Equation {
                         // Return the correct syntax in a binary component
                         return if sum == 0.0 && var != ' ' {
                             Component::Variable(var)
+                        } else if pos_left {
+                            Component::Binary { operator: if sum < 0.0 { '-' } else { '+' }, left: Box::new(Component::Variable(var)), right: Box::new(Component::Number(sum.abs())) }
                         } else {
-                            if pos_left {
-                                Component::Binary { operator: if sum < 0.0 { '-' } else { '+' }, left: Box::new(Component::Variable(var)), right: Box::new(Component::Number(sum.abs())) }
-                            } else {
-                                Component::Binary { operator: if sum < 0.0 { '-' } else { '+' }, left: Box::new(Component::Number(sum.abs())), right: Box::new(Component::Variable(var)) }
-                            }
+                            Component::Binary { operator: if sum < 0.0 { '-' } else { '+' }, left: Box::new(Component::Number(sum.abs())), right: Box::new(Component::Variable(var)) }
                         }
                     }
                 }
@@ -155,7 +153,7 @@ impl Equation {
                         _ => outcome
                     })
                 } else {
-                    (Component::Binary { operator: operator, left: Box::new(*left), right: Box::new(*right) }, outcome)
+                    (Component::Binary { operator, left: Box::new(*left), right: Box::new(*right) }, outcome)
                 }
             },
             _ => (Component::End, 0.0)
@@ -176,7 +174,7 @@ impl Equation {
         let mut expr = Self::solve(self.solve_with(vars), outcome);
 
         // Attempt to apply algebra while a binary component appears
-        while let Component::Binary { operator: _, left: _, right: _ } = &expr.0 {
+        while let Component::Binary { .. } = &expr.0 {
             expr = Self::solve(expr.0, expr.1);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod equation;
 #[cfg(test)]
 mod tests {
     use super::equation;
+    use super::parser;
 
     #[test]
     fn it_works() {
@@ -12,5 +13,13 @@ mod tests {
         assert_eq!(eq.solve_with(vec![('x', 10.0), ('a', 4.5), ('b', 1.0)]).to_float().unwrap(), 5.0);
         assert_eq!(eq.solve_for(10.0, vec![('a', 4.5), ('b', 1.0)]).1, 15.0);
         assert_eq!(equation::Equation::new("4 ^ x * 3").solve_for(192.0, vec![]).1, 3.0);
+    }
+
+    #[test]
+    fn test_to_string() {
+        let expression = "x + y * 3 - z ^ 7";
+        let component = parser::parse(expression);
+
+        assert_eq!(expression, component.to_string());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 use std::str::Chars;
 use std::iter::Peekable;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum Component {
@@ -13,19 +14,21 @@ pub enum Component {
     End
 }
 
-impl Component {
+impl fmt::Display for Component {
     // Converts component to a readable text
-    pub fn to_text(&self) -> String {
-        match self {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&match self {
             Component::Variable(c) => c.to_string(),
             Component::Number(f) => f.to_string(),
             Component::Binary { operator, left, right } => {
-                format!("{} {} {}", left.to_text(), operator, right.to_text())
+                format!("{} {} {}", left.to_string(), operator, right.to_string())
             },
             _ => String::from("")
-        }
+        })
     }
+}
 
+impl Component {
     // Tries to convert the component to a float if it is a number
     pub fn to_float(&self) -> Option<f32> {
         match self {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,7 +109,7 @@ fn parse_binary(chars: &mut Peekable<Chars>, prev_prec: i8, left: Component) -> 
 }
 
 // Parses component from an equation in string form
-pub fn parse(raw: &String) -> Component {
+pub fn parse(raw: &str) -> Component {
     // Removes all spaces from string
     let string = raw.chars().filter(|x| x != &' ').collect::<String>();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,7 @@ impl Component {
 }
 
 // Checks if character is an operator
-fn is_operator(c: &char) -> bool {
+fn is_operator(c: char) -> bool {
     match c {
         '+' | '-' | '*' | '/' | '%' | '^' => true,
         _ => false
@@ -47,8 +47,8 @@ fn is_operator(c: &char) -> bool {
 }
 
 // Checks if character is a floating point digit
-fn is_digit(c: &char) -> bool {
-    (*c >= '0' && *c <= '9') || *c == '.'
+fn is_digit(c: char) -> bool {
+    (c >= '0' && c <= '9') || c == '.'
 }
 
 // Get precedence (importance) of an operator
@@ -72,9 +72,9 @@ fn parse_component(chars: &mut Peekable<Chars>) -> Component {
     let mut maybe_num = String::new();
 
     while let Some(c) = chars.peek() {
-        if is_digit(c) { maybe_num.push(*c); }
+        if is_digit(*c) { maybe_num.push(*c); }
         else if !maybe_num.is_empty() { break; }
-        else if !is_operator(c) { return Component::Variable(*c); }
+        else if !is_operator(*c) { return Component::Variable(*c); }
         chars.next();
     }
 
@@ -87,7 +87,7 @@ fn parse_binary(chars: &mut Peekable<Chars>, prev_prec: i8, left: Component) -> 
     let mut left = left;
     loop {
         // Skips current character if it is not an operator
-        if let Some(c) = chars.peek() { if !is_operator(c) { chars.next(); } }
+        if let Some(c) = chars.peek() { if !is_operator(*c) { chars.next(); } }
 
         let c = chars.peek();
         // Gets precedence of current operator


### PR DESCRIPTION
Your to_text function does exactly what the std::string::ToString trait defines to_string(&self) for.
to_string(&self) is implemented automatically when implementing std::fmt::Display. That also makes println! stuff easier.